### PR TITLE
Allow button and tooltip text to be set like path and list

### DIFF
--- a/plugin/template/summernote-ext-template.js
+++ b/plugin/template/summernote-ext-template.js
@@ -28,6 +28,17 @@
       //  - you can create a button with `ui.button`
       var ui      = $.summernote.ui;
       var options = context.options.template;
+      var defaultOptions = {
+        label: "Template",
+        tooltip: "Insert Template"
+      };
+
+      // Assign default values if not supplied
+      for (var propertyName in defaultOptions) {
+        if (options.hasOwnProperty(propertyName) === false) {
+          options[propertyName] = defaultOptions[propertyName];
+        }
+      }
 
       // add hello button
       context.memo('button.template', function () {
@@ -35,8 +46,8 @@
         var button = ui.buttonGroup([
           ui.button({
             className: 'dropdown-toggle',
-            contents: '<span class="template"/> Template <span class="caret"></span>',
-            tooltip: 'Insert Template',
+            contents: '<span class="template"/> ' + options.label + ' <span class="caret"></span>',
+            tooltip: options.tooltip,
             data: {
               toggle: 'dropdown'
             }


### PR DESCRIPTION
I've made this change locally for a project im working on as i want the button and tooltip to have different text, and thought others might like to do it as well.

Basically, allows you to define `label` and `tooltip` to override the defaults.

``` javascript
template: {
    path: '/Scripts/summernote/templates',
    list: [
        'template1',
        'template2'
    ],
    label: 'My Custom Name',
    tooltip: 'This is the tooltip'
}
```
